### PR TITLE
Add admin mode with teacher login and authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Remember, it's self-paced so feel free to take a break! ☕️
 [![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/muhammadfyuliandi/skills-integrate-mcp-with-copilot/issues/1)
 
 ---
+**Admin Mode**
 
+Teachers can log in to manage student registrations. Credentials are stored in `src/teachers.json` and are verified by the backend using HTTP Basic authentication. Use the user icon in the top right of the web UI to open the login form; after successfully logging in you can register or unregister students.
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
 

--- a/src/app.py
+++ b/src/app.py
@@ -5,14 +5,40 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 import os
 from pathlib import Path
+import json
+import secrets
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+# Security setup for teacher authentication
+security = HTTPBasic()
+
+
+def verify_teacher(credentials: HTTPBasicCredentials = Depends(security)):
+    """Simple teacher credential check using a JSON file."""
+    path = Path(__file__).parent / "teachers.json"
+    if not path.exists():
+        raise HTTPException(status_code=500, detail="Teacher credential file missing")
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except Exception:
+        raise HTTPException(status_code=500, detail="Failed to read teacher credentials")
+
+    for t in data.get("teachers", []):
+        if t.get("username") == credentials.username and secrets.compare_digest(
+            t.get("password", ""), credentials.password
+        ):
+            return True
+
+    raise HTTPException(status_code=401, detail="Invalid teacher credentials")
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
@@ -88,9 +114,15 @@ def get_activities():
     return activities
 
 
+@app.get("/auth/check")
+def auth_check(authorized: bool = Depends(verify_teacher)):
+    """Endpoint for verifying teacher credentials from the frontend."""
+    return {"status": "ok"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, authorized: bool = Depends(verify_teacher)):
+    """Sign up a student for an activity. Only teachers may perform this action."""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +143,8 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(activity_name: str, email: str, authorized: bool = Depends(verify_teacher)):
+    """Unregister a student from an activity. Only teachers may perform this action."""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,17 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const loginIcon = document.getElementById("user-icon");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+
+  // Track current authorization header for teacher actions
+  let authHeader = null;
+
+  // Show or hide delete buttons based on auth state
+  function shouldShowDelete() {
+    return authHeader !== null;
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -14,6 +25,7 @@ document.addEventListener("DOMContentLoaded", () => {
       activitiesList.innerHTML = "";
 
       // Populate activities list
+      activitySelect.innerHTML = "<option value=\"\">-- Select an activity --</option>";
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");
         activityCard.className = "activity-card";
@@ -30,7 +42,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        shouldShowDelete()
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -56,7 +72,7 @@ document.addEventListener("DOMContentLoaded", () => {
         activitySelect.appendChild(option);
       });
 
-      // Add event listeners to delete buttons
+      // Add event listeners to delete buttons if they exist
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
@@ -74,13 +90,15 @@ document.addEventListener("DOMContentLoaded", () => {
     const email = button.getAttribute("data-email");
 
     try {
+      const options = {
+        method: "DELETE",
+        headers: authHeader ? { Authorization: authHeader } : {},
+      };
       const response = await fetch(
         `/activities/${encodeURIComponent(
           activity
         )}/unregister?email=${encodeURIComponent(email)}`,
-        {
-          method: "DELETE",
-        }
+        options
       );
 
       const result = await response.json();
@@ -118,13 +136,15 @@ document.addEventListener("DOMContentLoaded", () => {
     const activity = document.getElementById("activity").value;
 
     try {
+      const options = {
+        method: "POST",
+        headers: authHeader ? { Authorization: authHeader } : {},
+      };
       const response = await fetch(
         `/activities/${encodeURIComponent(
           activity
         )}/signup?email=${encodeURIComponent(email)}`,
-        {
-          method: "POST",
-        }
+        options
       );
 
       const result = await response.json();
@@ -152,6 +172,66 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  // Handle login icon click: open modal if not logged in, otherwise log out
+  loginIcon.addEventListener("click", () => {
+    if (authHeader) {
+      authHeader = null;
+      messageDiv.textContent = "Logged out";
+      messageDiv.className = "info";
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => messageDiv.classList.add("hidden"), 3000);
+      fetchActivities();
+    } else {
+      loginModal.classList.remove("hidden");
+    }
+  });
+
+  // close modal when clicking the X or outside the content
+  const modalClose = document.getElementById("modal-close");
+  modalClose.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+  });
+  loginModal.addEventListener("click", (e) => {
+    if (e.target === loginModal) {
+      loginModal.classList.add("hidden");
+    }
+  });
+
+  // Handle login form submission
+  loginForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const user = document.getElementById("username").value;
+    const pass = document.getElementById("password").value;
+    const trialHeader = "Basic " + btoa(`${user}:${pass}`);
+
+    // verify credentials with backend
+    try {
+      const resp = await fetch("/auth/check", {
+        headers: { Authorization: trialHeader },
+      });
+      if (resp.ok) {
+        authHeader = trialHeader;
+        loginModal.classList.add("hidden");
+        messageDiv.textContent = "Logged in as teacher";
+        messageDiv.className = "success";
+        messageDiv.classList.remove("hidden");
+        setTimeout(() => messageDiv.classList.add("hidden"), 3000);
+        fetchActivities();
+      } else {
+        messageDiv.textContent = "Invalid username or password";
+        messageDiv.className = "error";
+        messageDiv.classList.remove("hidden");
+        setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+      }
+    } catch (err) {
+      console.error("Login error", err);
+      messageDiv.textContent = "Login failed. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
     }
   });
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,7 +10,30 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <!-- user icon for admin login -->
+      <div id="user-icon" title="Teacher login" style="position:absolute; top:20px; right:20px; cursor:pointer; font-size:24px;">
+        👤
+      </div>
     </header>
+
+    <!-- login modal (hidden by default) -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <span id="modal-close" class="modal-close">&times;</span>
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required />
+          </div>
+          <button type="submit">Log In</button>
+        </form>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -198,3 +198,35 @@ footer {
   padding: 20px;
   color: #666;
 }
+
+/* Modal styles for login */
+.modal {
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 5px;
+  width: 90%;
+  max-width: 400px;
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  font-size: 24px;
+  cursor: pointer;
+}

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,8 @@
+{
+  "teachers": [
+    {
+      "username": "teacher1",
+      "password": "password123"
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces an admin mode where teachers must log in to manage student registrations.

### Key changes
- HTTP Basic auth via FastAPI for teacher endpoints
- `/auth/check` endpoint for frontend credential validation
- `/activities/*` signup/unregister require teacher credentials
- `src/teachers.json` holds sample credentials
- Frontend login modal accessible via user icon
- Only authenticated users see unregister buttons
- Added modal and credential handling to `app.js` and updated styles
- README now documents admin mode